### PR TITLE
Fix typo in undoing committed changes slide.

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@ git checkout hello_world.txt
         </section>
         <section>
           <h3>Nobody's Perfect</h3>
-          <h4>Undoing staged changes</h4>
+          <h4>Undoing committed changes</h4>
           <div class="fragment">
             <p>Open hello_world.txt and add some new text</p>
             <pre><code contenteditable class ="command-line">


### PR DESCRIPTION
Very minor update. This PR changes the wording on the third slide about undoing changes. I think it should say undoing "committed" and not "staged" changes. The progression seems to be local -> staging -> commit tree in the slides and based on the commands used. Granted, sometimes there is an overlap. 

@michellelynne 